### PR TITLE
Bugfix for ChromLinkMatrix.cc Enrichment function. Bugfix for CountMotifsInFasta.pl.

### DIFF
--- a/ChromLinkMatrix.cc
+++ b/ChromLinkMatrix.cc
@@ -769,6 +769,7 @@ ChromLinkMatrix::EnrichmentScore( const ContigOrdering & order ) const
   }
   
   // Calculate the average link density per bp of sequence.  Multiply the null score by this to convert it from a measure of length to a density of links.
+  if ( total_len_sq == 0 ) return 0; // handle case where all pairs are skipped.
   double link_density = double( N_links ) / total_len_sq;
   null_score *= link_density;
   assert( null_score != 0 );

--- a/CountMotifsInFasta.pl
+++ b/CountMotifsInFasta.pl
@@ -1,20 +1,20 @@
 #!/usr/bin/perl -w
 use strict;
 
-///////////////////////////////////////////////////////////////////////////////
-//                                                                           //
-// This software and its documentation are copyright (c) 2014-2015 by Joshua //
-// N. Burton and the University of Washington.  All rights are reserved.     //
-//                                                                           //
-// THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS  //
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF                //
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  //
-// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY      //
-// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT //
-// OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR  //
-// THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                //
-//                                                                           //
-///////////////////////////////////////////////////////////////////////////////
+#############################################################################
+#                                                                           #
+# This software and its documentation are copyright (c) 2014-2015 by Joshua #
+# N. Burton and the University of Washington.  All rights are reserved.     #
+#                                                                           #
+# THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS  #
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF                #
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  #
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY      #
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT #
+# OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR  #
+# THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                #
+#                                                                           #
+#############################################################################
 
 
 


### PR DESCRIPTION
On my system (Ubuntu 12.04) Lachesis throws errors when running CountMotifsInFasta.pl. I traced this back to the comment lines at the top of the script. When I replaced these with hashes the errors went away.

The next problem was Lachesis would abort with core dump with the following message:
Lachesis: ChromLinkMatrix.cc:775: double ChromLinkMatrix::EnrichmentScore(const ContigOrdering&) const: Assertion `!isnan( null_score )' failed.

The cause seems to be division by zero. At the top of the loop total_len_seq is set to 0 https://github.com/shendurelab/LACHESIS/blob/master/ChromLinkMatrix.cc/#L742
But what is happening, I think, is sometimes there will be a loop break on every iteration, and the loop will finish before anything has been added to total_len_seq:
https://github.com/shendurelab/LACHESIS/blob/master/ChromLinkMatrix.cc/#L758
Hence the division by zero leading to the failed assertion. The code handles one type of exception already: cases where there's only one contig, in which case the function returns 0. Therefore I'm returning zero when total_len_seq is zero (assuming this only happens due to skipping). I'm not sure if this is the best way to do things, but it allows the program to run to completion. Other people who are more familiar with the larger role of the function will have to tell me if that's going to break things downstream, but my philosophy is the program should handle all types of data, or give an informative message when it can't.